### PR TITLE
[히스] make original fixed data and apply dropout to berts

### DIFF
--- a/args.py
+++ b/args.py
@@ -13,8 +13,8 @@ def parse_args(mode='train'):
     parser.add_argument('--data_dir', default='/opt/ml/input/data/train_dataset', type=str, help='data directory')
     parser.add_argument('--asset_dir', default='asset/', type=str, help='data directory')
     
-    parser.add_argument('--train_file_name', default='fixed_train.csv', type=str, help='train file name')
-    parser.add_argument('--valid_file_name', default='fixed_valid.csv', type=str, help='valid file name')
+    parser.add_argument('--train_file_name', default='original_fixed_train.csv', type=str, help='train file name')
+    parser.add_argument('--valid_file_name', default='original_fixed_valid.csv', type=str, help='valid file name')
     
     parser.add_argument('--model_dir', default='models/', type=str, help='model directory')
 
@@ -41,7 +41,6 @@ def parse_args(mode='train'):
     parser.add_argument('--lr', default=0.0001, type=float, help='learning rate')
     parser.add_argument('--clip_grad', default=10, type=int, help='clip grad')
     parser.add_argument('--patience', default=5, type=int, help='for early stopping')
-    parser.add_argument('--split_data', default=0, type=int, help='split data')
     parser.add_argument('--is_decoder', default=True, type=bool, help='transformer decoder')
 
     # Sliding Window

--- a/dkt/model.py
+++ b/dkt/model.py
@@ -229,6 +229,8 @@ class Bert(nn.Module):
             num_attention_heads=self.args.n_heads,
             intermediate_size=self.hidden_dim*2,
             max_position_embeddings=self.args.max_seq_len,
+            hidden_dropout_prob=self.args.drop_out,
+            attention_probs_dropout_prob=self.args.drop_out,
             is_decoder=self.args.is_decoder
         )
 
@@ -631,7 +633,10 @@ class TfixupBert(nn.Module):
             hidden_size=self.hidden_dim,
             num_hidden_layers=self.args.n_layers,
             num_attention_heads=self.args.n_heads,
+            intermediate_size=self.hidden_dim*2,
             max_position_embeddings=self.args.max_seq_len,
+            hidden_dropout_prob=self.args.drop_out,
+            attention_probs_dropout_prob=self.args.drop_out,
             is_decoder=self.args.is_decoder         
         )
 

--- a/make_original_fixed_data.py
+++ b/make_original_fixed_data.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pandas as pd
+import os
+import random
+
+dtype = {
+    'userID': 'int16',
+    'answerCode': 'int8',
+    'KnowledgeTag': 'int16'
+}   
+
+DATA_PATH = '/opt/ml/input/data/train_dataset'
+train_org_df = pd.read_csv(os.path.join(DATA_PATH, "train_data_add_elapsed.csv"), dtype=dtype, parse_dates=['Timestamp'])
+train_org_df = train_org_df.sort_values(by=['userID', 'Timestamp']).reset_index(drop=True)
+
+u_id = train_org_df.userID.unique()
+random.seed(0)
+random.shuffle(u_id)
+size = int(len(u_id) * 0.2)
+u_id = u_id[:size]
+
+train_org_df.loc[~train_org_df.userID.isin(u_id), :].to_csv(os.path.join(DATA_PATH, "original_fixed_train.csv"), index=False)
+train_org_df.loc[train_org_df.userID.isin(u_id), :].to_csv(os.path.join(DATA_PATH, "original_fixed_valid.csv"), index=False)
+
+print(f"make original_fixed_data done")


### PR DESCRIPTION
1. 원래처럼 랜덤으로 셔플된 데이터를 사용합니다.
- make_original_fixed.py 실행하시면 됩니다. 금방 돌아용~.~
- original_fixed_train.csv, original_fixed_valid.csv 

2. bert 계열 모델에 drop out 적용안되던 문제 해결했습니다.